### PR TITLE
Moved to latest NAN 1.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gc-profiler",
   "description": "Allows you to profile when the garbage collector runs, and how long it takes.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Bret Copeland <bret@atlantisflight.org>",
   "main": "./main.js",
   "repository": {
@@ -16,6 +16,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "nan": "git+https://github.com/rvagg/nan.git#df2cdbcc4869af5ed1e29e2e6d5aeed9ad5a3f41"
+    "nan": "^1.6.2"
   }
 }


### PR DESCRIPTION
Changed dependency to NAN 1.6.2 - Example.js runs on 0.12 and iojs 1.2